### PR TITLE
Better wa to call Hook()

### DIFF
--- a/hook.h
+++ b/hook.h
@@ -10,6 +10,10 @@ inline void Hook(LPVOID target, LPVOID detour, LPVOID* original)
 {
 	reinterpret_cast<void(__stdcall*)(LPVOID target, LPVOID detour, LPVOID * original)>(GetProcAddress(GetModuleHandleA("4DModLoader-Core.dll"), "Hook"))(target, detour, original);
 }
+template<typename T> inline void Hook( unsigned long long target, T detour, T* original ) {
+	static_assert( std::is_function<typename std::remove_pointer<T>::type>::value, "Hook must be called with a function and a pointer to a function of identical signature");
+	Hook( reinterpret_cast<LPVOID>(target), reinterpret_cast<LPVOID>(detour), reinterpret_cast<LPVOID*>(original) );
+}
 
 // if target is NULL (0), enables every hook.
 inline void EnableHook(LPVOID target)

--- a/hook.h
+++ b/hook.h
@@ -10,8 +10,8 @@ inline void Hook(LPVOID target, LPVOID detour, LPVOID* original)
 {
 	reinterpret_cast<void(__stdcall*)(LPVOID target, LPVOID detour, LPVOID * original)>(GetProcAddress(GetModuleHandleA("4DModLoader-Core.dll"), "Hook"))(target, detour, original);
 }
-template<typename T> inline void Hook( unsigned long long target, T detour, T* original ) {
-	static_assert( std::is_function<typename std::remove_pointer<T>::type>::value, "Hook must be called with a function and a pointer to a function of identical signature");
+template<typename Function> inline void Hook( unsigned long long target, Function detour, Function* original ) {
+	static_assert( std::is_function<typename std::remove_pointer<Function>::type>::value, "Hook must be called with a function and a pointer to a function of identical signature");
 	Hook( reinterpret_cast<LPVOID>(target), reinterpret_cast<LPVOID>(detour), reinterpret_cast<LPVOID*>(original) );
 }
 


### PR DESCRIPTION
Allows using for example  
`Hook( FUNC_PLAYER_KEYINPUT, &Player_keyInput_H, &Player_keyInput );`  
instead of  
`Hook( reinterpret_cast<void*>(FUNC_PLAYER_KEYINPUT), reinterpret_cast<void*>(&Player_keyInput_H), reinterpret_cast<void**>(&Player_keyInput) );` 

Further, this is not only easier to read and write, it does proper type-checking.  
It checks that the second and third arguments are a functionpointer and a pointer to a functionpointer, and that the signatures of the functions match (i.e. you are hooking a function with a matching function)