### PR TITLE
remove useless class placeholders

### DIFF
--- a/CraftingMenu.h
+++ b/CraftingMenu.h
@@ -11,8 +11,6 @@ namespace fdm
 
 	class InventoryManager;
 	class InventoryCursor;
-	class gui::Window;
-	class gui::Element;
 	class Item;
 
 	class CraftingMenu : public gui::Element 

--- a/Player.h
+++ b/Player.h
@@ -15,7 +15,6 @@ namespace fdm
 	class InventoryGrid;
 	class InventoryManager;
 	class InventoryPlayer;
-	class m4::Mat5;
 	class MeshRenderer;
 	class TexRenderer;
 	class FontRenderer;


### PR DESCRIPTION
The three removed class stubs are literally imported properly at the beginning of their files. This rightfully leads to warnings cluttering up the build of every mod unnecessarily.