### PR TITLE
Fix UB

### DIFF
--- a/m4.h
+++ b/m4.h
@@ -149,7 +149,7 @@ namespace fdm
 			{
 				return { 1 };
 			}
-			Mat5& operator*(const Mat5& other) const
+			Mat5 operator*(const Mat5& other) const
 			{
 				Mat5 result{ 1 };
 


### PR DESCRIPTION
You are creating the local variable result and passing it out to the caller. Thus the caller needs to take permission of it. Passing it by alias will mean it gets deallocated, an alias into unallocated memory.

also this removes more annoying compiler warnings, because the compiler doesn't like UB either.