### PR TITLE
Correct behavior of Text elements capturing Tabbing through elements

### DIFF
--- a/GUI/Text.h
+++ b/GUI/Text.h
@@ -18,6 +18,7 @@ namespace fdm::gui
 		bool shadow; // 0x50
 		bool fancy; // 0x51
 
+		bool enabled() override {return false;}
 		void render(gui::Window* w) override
 		{
 			return reinterpret_cast<void (__thiscall*)(gui::Text* self, gui::Window* w)>(FUNC_GUI_TEXT_RENDER)(this, w);


### PR DESCRIPTION
I think you need to add `bool enabled() override {return false;}` to gui::Text, I see no possible case where a gui::Text element would need to be interactive.