### PR TITLE
Fix addElement and removeElement of gui::Interface

### DIFF
--- a/GUI/ContentBox.h
+++ b/GUI/ContentBox.h
@@ -179,7 +179,7 @@ namespace fdm
 			}
 			bool removeElement(gui::Element* e) override
 			{
-				return elements.erase(std::remove(elements.begin(), elements.end(), e), elements.end()) != elements.end();
+				return std::erase(elements,e);
 			}
 			bool selectElement(gui::Element* e) override
 			{

--- a/GUI/Interface.h
+++ b/GUI/Interface.h
@@ -83,13 +83,13 @@ namespace fdm
 			{
 				return reinterpret_cast<void(__thiscall*)(gui::Interface * self, const glm::ivec4 & pos, const glm::ivec2 & scroll)>(FUNC_GUI_INTERFACE_CHANGEVIEWPORT)(this, pos, scroll);
 			}
-			void addElement(gui::Element* e) override
-			{
-				return reinterpret_cast<void(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_ADDELEMENT)(this, e);
+			void addElement(gui::Element* e) override {
+				// return reinterpret_cast<void(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_ADDELEMENT)(this, e);
+				this->elements.push_back(e);
 			}
-			bool removeElement(gui::Element* e) override
-			{
-				return reinterpret_cast<bool(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_REMOVEELEMENT)(this, e);
+			bool removeElement(gui::Element* e) override {
+				// return reinterpret_cast<bool(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_REMOVEELEMENT)(this, e);
+				return std::erase(this->elements,e);
 			}
 			bool selectElement(gui::Element* e) override
 			{

--- a/GUI/Interface.h
+++ b/GUI/Interface.h
@@ -85,11 +85,11 @@ namespace fdm
 			}
 			void addElement(gui::Element* e) override {
 				// return reinterpret_cast<void(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_ADDELEMENT)(this, e);
-				this->elements.push_back(e);
+				elements.push_back(e);
 			}
 			bool removeElement(gui::Element* e) override {
 				// return reinterpret_cast<bool(__thiscall*)(gui::Interface * self, gui::Element * e)>(FUNC_GUI_INTERFACE_REMOVEELEMENT)(this, e);
-				return std::erase(this->elements,e);
+				return std::erase(elements,e);
 			}
 			bool selectElement(gui::Element* e) override
 			{


### PR DESCRIPTION
For some reason FUNC_GUI_INTERFACE_ADDELEMENT and FUNC_GUI_INTERFACE_REMOVEELEMENT don't appear to work, so I recreated them, since their behavior was pretty easy to replicate.
Also I came up with a better way than ContentBox has, so I replaced that too.