### PR TITLE
Fix improper enum definitions

### DIFF
--- a/GUI/Alignment.h
+++ b/GUI/Alignment.h
@@ -6,13 +6,13 @@ namespace fdm
 {
 	namespace gui
 	{
-		enum AlignmentX 
+		enum AlignmentX: int
 		{
 			ALIGN_LEFT = 0,
 			ALIGN_RIGHT = 1,
 			ALIGN_CENTER_X = 2
 		};
-		enum AlignmentY
+		enum AlignmentY: int
 		{
 			ALIGN_TOP = 0,
 			ALIGN_BOTTOM = 1,

--- a/GUI/Element.h
+++ b/GUI/Element.h
@@ -5,8 +5,8 @@
 
 namespace fdm::gui
 {
-	enum AlignmentX;
-	enum AlignmentY;
+	enum AlignmentX: int;
+	enum AlignmentY: int;
 	class Window;
 	class Element 
 	{


### PR DESCRIPTION
In C++, prior to C++11, enum declarations without an underlying type specifier were considered forward declarations. However, starting from C++11, enum declarations without an underlying type specifier are still valid, but they declare enums without fixed underlying types.

In short, this works in msvc, because it doesn't follow the C++ standard very well, but it doesn't work in other compilers.

Also I removed a random trailing space :)