### PR TITLE
Add EnableHook alias for uintptr_t for compatibility with Hook

### DIFF
--- a/hook.h
+++ b/hook.h
@@ -21,6 +21,9 @@ template<typename FuncPtr> inline void Hook( unsigned long long target, FuncPtr 
 inline void __stdcall EnableHook(LPVOID target){ // enables specific hook.
 	reinterpret_cast<void(__stdcall*)(LPVOID target)>(GetProcAddress(GetModuleHandleA("4DModLoader-Core.dll"), "EnableHook"))(target);
 }
+inline void __stdcall EnableHook(unsigned long long target){ // enables specific hook.
+	reinterpret_cast<void(__stdcall*)(LPVOID target)>(GetProcAddress(GetModuleHandleA("4DModLoader-Core.dll"), "EnableHook"))(reinterpret_cast<LPVOID>(target));
+}
 inline void EnableHook(){ // enables every hook.
 	EnableHook(nullptr);
 }


### PR DESCRIPTION
In my keybinds rewrite I have
```cpp
std::unordered_map<KeyBindsScope,uintptr_t> KeyBindsScopeAddrs = {
	{ GLOBAL, fdm::Func::main_cpp::keyCallback },
	// ...
};
```
And for example
```cpp
template<auto scope> constexpr void instantiate(){
	Hook( KeyBindsScopeAddrs[scope], generic_keyinput<scope>, &originals[scope] );
}
```
to match, as it is intended. `generic_keyinput<scope>` and `originals[scope]` are functions of equal signature.

I however now cannot run 
```cpp
for (int i = 0; i < __LAST; i++ )  // same as above but at runtime
	EnableHook(KeyBindsScopeAddrs[KeyBindsScope(i)]);  // enable all the hooks we just created
```
I would have to cast to LPVOID.
As long as fdm::Func defines shit as non-LPVOID, there needs to be EnableHook accepting that type.