### PR TITLE
unbreak hook static in mingw

### DIFF
--- a/4dm.h
+++ b/4dm.h
@@ -1428,8 +1428,8 @@ to call the original function, do `original(<all of the you have arguments>)`
 		class CONCAT(function, H)  \
 		{ \
 		public: \
-			inline static returnType(__fastcall* original)(##__VA_ARGS__) = nullptr;\
-			static returnType __fastcall hook(##__VA_ARGS__); \
+			inline static returnType(__fastcall* original)(__VA_ARGS__) = nullptr;\
+			static returnType __fastcall hook(__VA_ARGS__); \
 		}; \
 	} \
 	$exec \
@@ -1439,7 +1439,7 @@ to call the original function, do `original(<all of the you have arguments>)`
 		Hook(hookAddr, &CONCAT(fdmHooks, __LINE__)::CONCAT(function, H)::hook, &CONCAT(fdmHooks, __LINE__)::CONCAT(function, H)::original); \
 		EnableHook(); \
 	} \
-	inline returnType __fastcall CONCAT(fdmHooks, __LINE__)::CONCAT(function, H)::hook(##__VA_ARGS__)
+	inline returnType __fastcall CONCAT(fdmHooks, __LINE__)::CONCAT(function, H)::hook(__VA_ARGS__)
 
 /*
 creates a hook for a static function (__fastcall) using Func namespace.
@@ -1451,8 +1451,8 @@ to call the original function, do `original(<all of the you have arguments>)`
 		class H \
 		{ \
 		public: \
-			inline static returnType(__fastcall* original)(##__VA_ARGS__) = nullptr; \
-			static returnType __fastcall hook(##__VA_ARGS__); \
+			inline static returnType(__fastcall* original)(__VA_ARGS__) = nullptr; \
+			static returnType __fastcall hook(__VA_ARGS__); \
 		}; \
 	} \
 	$exec \
@@ -1462,7 +1462,7 @@ to call the original function, do `original(<all of the you have arguments>)`
 		Hook(hookAddr, &CONCAT(fdmHooks, __LINE__)::H::hook, &CONCAT(fdmHooks, __LINE__)::H::original); \
 		EnableHook(); \
 	} \
-	inline returnType __fastcall CONCAT(fdmHooks, __LINE__)::H::hook(##__VA_ARGS__)
+	inline returnType __fastcall CONCAT(fdmHooks, __LINE__)::H::hook(__VA_ARGS__)
 
 #ifdef DEBUG_CONSOLE
 #define initDLL \


### PR DESCRIPTION
Yeah so when I previously added these I should have not added them for the static versions.

msvc probably doesn't see these either because it still doesn't implement __VA_ARGS__ according to the spec